### PR TITLE
tasks: wait_until_role_is_up

### DIFF
--- a/fabric_utils/tasks.py
+++ b/fabric_utils/tasks.py
@@ -78,14 +78,14 @@ def check_http_is_200_ok():
     with settings(hide('stdout')):
         command = 'curl -sSL -D - {healthcheck_url} -o /dev/null | head -n 1 | grep "200 OK"'.format(
             healthcheck_url=env.healthcheck_url)
-        result = sudo(command, warn_only=True, user=env.user)
+        result = sudo(command, warn_only=True, shell=False, user=env.user)
         return result
 
 
 def check_role_is_up(role, check_task_func):
-    is_uwsgi_up_values = execute(check_task_func, role=role).values()
-    all_hosts_up = all(r.succeeded for r in is_uwsgi_up_values)
-    joint_stderr = '\n'.join(r.stdout for r in is_uwsgi_up_values)
+    is_service_up_values = execute(check_task_func, role=role).values()
+    all_hosts_up = all(r.succeeded for r in is_service_up_values)
+    joint_stderr = '\n'.join(r.stdout for r in is_service_up_values)
     return all_hosts_up, joint_stderr
 
 

--- a/fabric_utils/tasks.py
+++ b/fabric_utils/tasks.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 import re
+from time import sleep
 
-from fabric.context_managers import lcd, settings, hide
-from fabric.decorators import task, runs_once
-from fabric.operations import local
-from fabric.state import env
-from fabric.utils import puts
+from fabric.api import puts, local, task, runs_once, lcd, settings, hide, env
+from fabric.operations import sudo
+from fabric.tasks import execute
+from fabric.utils import error
 
 
 @task
@@ -60,3 +60,62 @@ def sqlmigrate(from_branch='origin/develop', to_branch='origin/master', prefix='
                 local('python manage.py sqlmigrate %s %s' % (match.group(1), match.group(2)))
     if from_branch != current_remote:
         local('git checkout -')
+
+
+@task
+def check_uwsgi_is_200_ok():
+    global app
+
+    with app.activate(), settings(hide('stdout')):
+        command = 'uwsgi_curl 127.0.0.1:{uwsgi_port} {healthcheck_url} | head -n 1 | grep "200 OK"'.format(
+            uwsgi_port=env.uwsgi_port, healthcheck_url=env.healthcheck_url)
+        result = sudo(command, warn_only=True, user=env.user)
+        return result
+
+
+@task
+def check_http_is_200_ok():
+    with settings(hide('stdout')):
+        command = 'curl -sSL -D - {healthcheck_url} -o /dev/null | head -n 1 | grep "200 OK"'.format(
+            healthcheck_url=env.healthcheck_url)
+        result = sudo(command, warn_only=True, user=env.user)
+        return result
+
+
+def check_role_is_up(role, check_task_func):
+    is_uwsgi_up_values = execute(check_task_func, role=role).values()
+    all_hosts_up = all(r.succeeded for r in is_uwsgi_up_values)
+    joint_stderr = '\n'.join(r.stdout for r in is_uwsgi_up_values)
+    return all_hosts_up, joint_stderr
+
+
+def wait_until_role_is_up(role,
+                          healthcheck_url,
+                          check_task_func=check_http_is_200_ok,
+                          poll_interval_seconds=10,
+                          max_wait_seconds=20,
+                          warn_only=False):
+    """
+    Wait until all role hosts are considered healthy, e.g. returns 200 OK in response to GET healthcheck_url
+
+    :param role:
+    :param healthcheck_url: URL that must return 200 OK for host to be considered healthy
+    :param check_task_func: fabric task that does actual check, returns command result
+    :param poll_interval_seconds: health checks frequency in seconds
+    :param max_wait_seconds: maximum global wait timeout across all healthchecks
+    :param warn_only: If False (default), abort execution
+    :return: boolean
+    """
+    wait = 0
+    stderr = '-'
+    while wait < max_wait_seconds:
+        wait += poll_interval_seconds
+        sleep(poll_interval_seconds)
+        with settings(healthcheck_url=healthcheck_url):
+            is_up, stderr = check_role_is_up(role, check_task_func)
+        if is_up:
+            return True
+    else:
+        with settings(warn_only=warn_only):
+            error('Waited for %s seconds, role %s is not up. %s \n %s' % (
+                wait, role, 'Aborting' if not warn_only else '', stderr))


### PR DESCRIPTION
Add common task `wait_until_role_is_up`, usage::

```
wait_until_role_is_up(role='web1', healthcheck_url='http://127.0.0.1:3101', warn_only=False)
```

If all servers report 200 OK after `poll_interval_seconds` in response to GET `healthcheck_url`, continue. If any host fails, deploy is aborted:

```
Warning: sudo() received nonzero return code 1 while executing 'curl -sSL -D - http://127.0.0.1:3101 -o /dev/null | head -n 1 | grep "200 OK"'!


Warning: sudo() received nonzero return code 1 while executing 'curl -sSL -D - http://127.0.0.1:3101 -o /dev/null | head -n 1 | grep "200 OK"'!
```

https://explainshell.com/explain?cmd=curl+-sSL+-D+-+http%3A%2F%2F127.0.0.1%3A3101+-o+%2Fdev%2Fnull+%7C+head+-n+1+%7C+grep+%22200+OK%22